### PR TITLE
Improve Add Common Words UI in Progress page

### DIFF
--- a/src/app/components/WordCategories.tsx
+++ b/src/app/components/WordCategories.tsx
@@ -7,9 +7,18 @@ import { Edit2 } from 'lucide-react';
 interface WordCategoriesProps {
   language: string;
   selectedCategory: string | null;
+  categories: { category: string; icon: string | null }[];
+  onSelectCategory: (category: string) => void;
+  categoriesLoading: boolean;
 }
 
-const WordCategories: React.FC<WordCategoriesProps> = ({ language, selectedCategory }) => {
+const WordCategories: React.FC<WordCategoriesProps> = ({
+  language,
+  selectedCategory,
+  categories,
+  onSelectCategory,
+  categoriesLoading,
+}) => {
   const [selectedWords, setSelectedWords] = useState<number[]>([]);
   const [lastSelectedIndex, setLastSelectedIndex] = useState<number | null>(null);
   const [hoveredRow, setHoveredRow] = useState<number | null>(null);
@@ -72,9 +81,25 @@ const WordCategories: React.FC<WordCategoriesProps> = ({ language, selectedCateg
   };
 
   if (!selectedCategory) {
+    if (categoriesLoading) {
+      return (
+        <div className="flex items-center justify-center h-64 text-gray-500">
+          Loading categories...
+        </div>
+      );
+    }
+
     return (
-      <div className="flex items-center justify-center h-64 text-gray-500">
-        Select a category above to see its most common words you haven't added yet.
+      <div className="p-4 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+        {categories.map((cat) => (
+          <div
+            key={cat.category}
+            onClick={() => onSelectCategory(cat.category)}
+            className="cursor-pointer rounded-md bg-gray-100 hover:bg-gray-200 text-center py-6 text-gray-700"
+          >
+            {cat.category}
+          </div>
+        ))}
       </div>
     );
   }

--- a/src/app/progress/page.tsx
+++ b/src/app/progress/page.tsx
@@ -76,6 +76,13 @@ const ProgressPage = () => {
     error: wordsKnownError,
   } = useWordsKnownByDate();
   const { categories, isLoading: categoriesLoading } = useCategories("es");
+  const filteredCategories = useMemo(
+    () =>
+      categories.filter(
+        (c) => c.category !== "Unknown" && c.category !== "Failed"
+      ),
+    [categories]
+  );
 
   useLayoutEffect(() => {
     const updateUnderline = () => {
@@ -286,7 +293,7 @@ const ProgressPage = () => {
                   disabled={categoriesLoading}
                 >
                   <option value="">Select Category</option>
-                  {categories?.map((categoryObj) => (
+                  {filteredCategories.map((categoryObj) => (
                     <option key={categoryObj.category} value={categoryObj.category}>
                       {categoryObj.category}
                     </option>
@@ -306,7 +313,13 @@ const ProgressPage = () => {
             {selectedView === "editVocabulary" ? (
               <KnownWords searchTerm={debouncedSearchTerm} />
             ) : (
-              <WordCategories language="es" selectedCategory={selectedCategory} />
+              <WordCategories
+                language="es"
+                selectedCategory={selectedCategory}
+                categories={filteredCategories}
+                onSelectCategory={(c) => setSelectedCategory(c)}
+                categoriesLoading={categoriesLoading}
+              />
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- filter out `Unknown` and `Failed` categories on progress page
- pass category list and select handler to `WordCategories`
- show category cards when none selected

## Testing
- `npm run lint` *(fails: various ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68444b20f4308328a55188defa14b228