### PR TITLE
Fix LearningWordsTable sticky footer and shift selection

### DIFF
--- a/src/app/components/KnownWords.tsx
+++ b/src/app/components/KnownWords.tsx
@@ -104,7 +104,13 @@ const KnownWords: React.FC<KnownWordsProps> = ({ searchTerm }) => {
       const newSelectedWords = displayWords
         .slice(rangeStart, rangeEnd + 1)
         .map(word => word.word_id);
-      setSelectedWords(prev => Array.from(new Set([...prev, ...newSelectedWords])));
+      setSelectedWords(prev => {
+        const isRemoving = prev.includes(wordId);
+        if (isRemoving) {
+          return prev.filter(id => !newSelectedWords.includes(id));
+        }
+        return Array.from(new Set([...prev, ...newSelectedWords]));
+      });
     } else {
       toggleWordSelection(wordId);
       setLastSelectedIndex(index);

--- a/src/app/components/LearningWordsTable.tsx
+++ b/src/app/components/LearningWordsTable.tsx
@@ -139,7 +139,13 @@ const LearningWordsTable: React.FC = () => {
       const rangeStart = Math.min(index, lastSelectedIndex);
       const rangeEnd = Math.max(index, lastSelectedIndex);
       const newSelected = words.slice(rangeStart, rangeEnd + 1).map((w) => w.word_id);
-      setSelectedWords((prev) => Array.from(new Set([...prev, ...newSelected])));
+      setSelectedWords((prev) => {
+        const isRemoving = prev.includes(wordId);
+        if (isRemoving) {
+          return prev.filter((id) => !newSelected.includes(id));
+        }
+        return Array.from(new Set([...prev, ...newSelected]));
+      });
     } else {
       toggleWordSelection(wordId);
       setLastSelectedIndex(index);
@@ -170,7 +176,7 @@ const LearningWordsTable: React.FC = () => {
 
   /* render */
   return (
-    <div className="bg-white mt-10 shadow-md rounded-lg">
+    <div className="bg-white mt-10 shadow-md rounded-lg flex flex-col h-full">
       {/* header */}
       <div className="flex items-center bg-gray-100 px-4 py-3 rounded-t-lg gap-4">
         <h2 className="text-lg font-semibold text-gray-700">Your Learning Words</h2>
@@ -188,8 +194,18 @@ const LearningWordsTable: React.FC = () => {
         </div>
       </div>
 
+      <style jsx global>{`
+        .hide-scrollbar {
+          scrollbar-width: none;
+          -ms-overflow-style: none;
+        }
+        .hide-scrollbar::-webkit-scrollbar {
+          display: none;
+        }
+      `}</style>
+
       {/* table */}
-      <div className="overflow-auto pb-16">
+      <div className="flex-grow overflow-auto pb-16 hide-scrollbar">
         <table
           className="w-full min-w-max table-auto"
           onMouseDown={(e) => e.shiftKey && e.preventDefault()}


### PR DESCRIPTION
## Summary
- match LearningWordsTable layout to Progress page style
- allow deselecting ranges when shift-clicking on already selected rows
- apply the same shift-click behavior to KnownWords

## Testing
- `npm run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444d77be8c83289a35209dd44ce15d