### PR TITLE
Fix category encoding

### DIFF
--- a/src/app/components/WordCategories.tsx
+++ b/src/app/components/WordCategories.tsx
@@ -95,7 +95,7 @@ const WordCategories: React.FC<WordCategoriesProps> = ({
           <div
             key={cat.category}
             onClick={() => onSelectCategory(cat.category)}
-            className="cursor-pointer rounded-md bg-gray-100 hover:bg-gray-200 text-center py-6 text-gray-700"
+            className="cursor-pointer rounded-md bg-white hover:bg-gray-100 text-center py-6 text-gray-700"
           >
             {cat.category}
           </div>

--- a/src/app/hooks/useArticleRecommendations.ts
+++ b/src/app/hooks/useArticleRecommendations.ts
@@ -43,7 +43,7 @@ export const useArticleRecommendations = (selectedCategory: string) => {
   useEffect(() => {
     const fetchArticles = async () => {
       try {
-        const categoryParam = selectedCategory === 'All Articles' ? '' : `&category=${selectedCategory}`;
+        const categoryParam = selectedCategory === 'All Articles' ? '' : `&category=${encodeURIComponent(selectedCategory)}`;
         const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
         const response = await fetchWithAuth(`${API_URL}/recommendations/articles/?language=${language?.code}${categoryParam}`);
         

--- a/src/app/hooks/useWordRecommendations.ts
+++ b/src/app/hooks/useWordRecommendations.ts
@@ -19,7 +19,7 @@ export const useWordRecommendations = (category: string | null) => {
             if (!category) return;
 
             try {
-                const categoryParam = category ? `&category=${category}` : '';
+                const categoryParam = category ? `&category=${encodeURIComponent(category)}` : '';
                 const response = await fetchWithAuth(
                     `${API_URL}/recommendations/words/?language=${language?.code}${categoryParam}`
                 );


### PR DESCRIPTION
## Summary
- encode category names to handle whitespace when requesting word and article recommendations
- make word recommendation cards white when no category is selected

## Testing
- `npm run lint` *(fails: next command not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68444e2e3edc8328bf29f0ef766bbbf8