### PR TITLE
Fix language initialization RPC call

### DIFF
--- a/src/app/components/LanguageSetup.tsx
+++ b/src/app/components/LanguageSetup.tsx
@@ -100,31 +100,26 @@ const LanguageSetup: React.FC<LanguageSetupProps> = ({
     if (selectedLanguage && selectedLevel) {
       setIsInitializing(true);
       try {
-        // Initialize the language
+        // Initialize the language on the server first
+        await initializeLanguage(selectedLanguage.code, selectedLevel.level);
 
-        setTimeout(() => {
-          if (onComplete) {
-            console.log("Y")
-            onComplete();
-            initializeLanguage(selectedLanguage.code, selectedLevel.level);
-          } else {
-            // Default behavior - redirect to videos
-            router.push('/videos');
-          }
-        }, 1500);
-
-        
-        
         // Update the context with the new language
         setLanguage({
           code: selectedLanguage.code,
           name: selectedLanguage.name,
           flag: selectedLanguage.code // for backward compatibility
         });
-        
+
         setIsComplete(true);
-        
-        // Wait a moment to show success message, then proceed
+
+        // After showing the success message, redirect
+        setTimeout(() => {
+          if (onComplete) {
+            onComplete();
+          } else {
+            router.push('/videos');
+          }
+        }, 1500);
         
       } catch (error) {
         console.error('Error initializing language:', error);

--- a/src/app/hooks/useInitializeAccount.ts
+++ b/src/app/hooks/useInitializeAccount.ts
@@ -1,23 +1,13 @@
 import { supabase } from '@/lib/supabaseclient';
 
 export const useInitializeAccount = () => {
-  const initializeUserAccount = async (language: string, languageLevel: string) => {
+  const initializeUserAccount = async (
+    language: string,
+    languageLevel: string
+  ) => {
     try {
-      console.log('-- Initializing user account for language:', language, 'and language level:', languageLevel);
-
-      // Map language codes (e.g., 'es') to full language names (e.g., 'Spanish')
-      const codeToName: Record<string, string> = {
-        es: 'spanish',
-        de: 'german',
-        fr: 'french',
-        it: 'italian',
-        // Add more as needed
-      };
-
-      const languageName = codeToName[language.toLowerCase()] || language;
-
       const { data, error } = await supabase.rpc('initialize_account', {
-        _language: languageName,
+        _language: language,
         _language_level: languageLevel,
       });
 


### PR DESCRIPTION
## Summary
- use language codes directly when calling `initialize_account`

## Testing
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6844502986ec83289fbb1ec56b7cbd5c