### PR TITLE
Fix sticky button for LearningWordsTable

### DIFF
--- a/src/app/vocabulary/page.tsx
+++ b/src/app/vocabulary/page.tsx
@@ -91,7 +91,7 @@ const VocabularyLearnerWithStreak = () => {
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
       </Head>
-      <div className="w-full bg-white overflow-hidden">
+      <div className="w-full bg-white">
         <Header currentStreak={currentStreak} />
 
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6">


### PR DESCRIPTION
## Summary
- ensure sticky button works in vocabulary view by removing overflow on the container

## Testing
- `npm run lint` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684453e3930c8328aee00966d3d4eb03