### PR TITLE
Update vocabulary filtering for practice counts

### DIFF
--- a/src/app/components/LearningWordsTable.tsx
+++ b/src/app/components/LearningWordsTable.tsx
@@ -77,7 +77,15 @@ const SourcesDropdown: React.FC<SourcesDropdownProps> = ({ sources, current, onC
 };
 
 /* main component */
-const LearningWordsTable: React.FC = () => {
+interface LearningWordsTableProps {
+  onMovedToKnown?: () => void;
+  onSourceChange?: (s: string) => void;
+}
+
+const LearningWordsTable: React.FC<LearningWordsTableProps> = ({
+  onMovedToKnown,
+  onSourceChange,
+}) => {
   /* source dropdown */
   const [sources, setSources] = useState<string[]>([]);
   const [sourceFilter, setSourceFilter] = useState<string>('all');
@@ -157,6 +165,7 @@ const LearningWordsTable: React.FC = () => {
       await updateUserwordsStatus(selectedWords, 'known');
       setWords((prev) => prev.filter((w) => !selectedWords.includes(w.word_id)));
       setSelectedWords([]);
+      onMovedToKnown?.();
     } catch (err) {
       console.error('Error updating userwords status:', err);
     }
@@ -183,7 +192,14 @@ const LearningWordsTable: React.FC = () => {
 
         {/* right‑aligned group */}
         <div className="flex items-center gap-4 ml-auto">
-          <SourcesDropdown sources={sources} current={sourceFilter} onChange={setSourceFilter} />
+          <SourcesDropdown
+            sources={sources}
+            current={sourceFilter}
+            onChange={(s) => {
+              setSourceFilter(s);
+              onSourceChange?.(s);
+            }}
+          />
           <input
             type="text"
             placeholder="Search…"

--- a/src/app/vocabulary/page.tsx
+++ b/src/app/vocabulary/page.tsx
@@ -23,8 +23,11 @@ const VocabularyLearnerWithStreak = () => {
   const [selectedWord, setSelectedWord] = useState<any | null>(null);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const [wordsDueToday, setWordsDueToday] = useState<any[]>([]);
+  const [sourceFilter, setSourceFilter] = useState<string>('all');
 
-  const { overdueWords, error: overdueError } = useOverdueWords(refreshTrigger);
+  const { overdueWords, error: overdueError } = useOverdueWords(refreshTrigger, {
+    source: sourceFilter === 'all' ? undefined : sourceFilter,
+  });
   const { topWords, error: topError } = useTopWords(refreshTrigger);
   const { streakData, currentStreak, highestStreak } = useStreakData(refreshTrigger);
 
@@ -50,6 +53,10 @@ const VocabularyLearnerWithStreak = () => {
     setShowSession(false);
     handleRefresh();
   }, [handleRefresh]);
+
+  const handleSourceChange = useCallback((src: string) => {
+    setSourceFilter(src);
+  }, []);
 
   const handleWordClick = (word: any) => {
     setSelectedWord(word);
@@ -105,7 +112,10 @@ const VocabularyLearnerWithStreak = () => {
           />
 
           {/* New LearningWordsTable with integrated header and search bar */}
-          <LearningWordsTable />
+          <LearningWordsTable
+            onMovedToKnown={handleRefresh}
+            onSourceChange={handleSourceChange}
+          />
         </div>
 
 


### PR DESCRIPTION
## Summary
- allow LearningWordsTable to notify parent about source filtering and list updates
- sync Vocabulary page source state with useOverdueWords

## Testing
- `npm run lint` *(fails: several lint errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_68444f5d578883288e10c7186b17bf09