### PR TITLE
Fix word list refresh on progress page

### DIFF
--- a/src/app/components/WordCategories.tsx
+++ b/src/app/components/WordCategories.tsx
@@ -24,9 +24,11 @@ const WordCategories: React.FC<WordCategoriesProps> = ({
   const [hoveredRow, setHoveredRow] = useState<number | null>(null);
   const [displayedWordIds, setDisplayedWordIds] = useState<number[]>([]);
 
-  const { recommendations, loading: recommendationsLoading } = useWordRecommendations(
-    selectedCategory
-  );
+  const {
+    recommendations,
+    loading: recommendationsLoading,
+    refreshRecommendations,
+  } = useWordRecommendations(selectedCategory);
   const { words: wordDetails } = useWordDetails(recommendations?.word_ids || []);
   const { addWordsToUserwords } = useUpdateUserwords();
 
@@ -70,6 +72,7 @@ const WordCategories: React.FC<WordCategoriesProps> = ({
       // Remove added words from displayed words
       setDisplayedWordIds(prev => prev.filter(id => !selectedWords.includes(id)));
       setSelectedWords([]);
+      refreshRecommendations();
     } catch (err) {
       console.error('Error adding words:', err);
     }

--- a/src/app/hooks/useWordRecommendations.ts
+++ b/src/app/hooks/useWordRecommendations.ts
@@ -14,36 +14,42 @@ export const useWordRecommendations = (category: string | null) => {
     const [error, setError] = useState<string | null>(null);
     const { fetchWithAuth, language } = useContext(UserContext);
 
-    useEffect(() => {
-        const fetchRecommendations = async () => {
-            if (!category) return;
+    const fetchRecommendations = async () => {
+        if (!category) return;
 
-            try {
-                const categoryParam = category ? `&category=${encodeURIComponent(category)}` : '';
-                const response = await fetchWithAuth(
-                    `${API_URL}/recommendations/words/?language=${language?.code}${categoryParam}`
-                );
+        setIsLoading(true);
+        try {
+            const categoryParam = category ? `&category=${encodeURIComponent(category)}` : '';
+            const response = await fetchWithAuth(
+                `${API_URL}/recommendations/words/?language=${language?.code}${categoryParam}`
+            );
 
-                if (!response.ok) {
-                    throw new Error('Failed to fetch word recommendations');
-                }
-
-                const data = await response.json();
-                setRecommendations({
-                    word_ids: data.word_ids,
-                    improvements: data.improvements,
-                    frequencies: data.frequencies
-                });
-            } catch (err) {
-                console.error(err);
-                setError('Failed to load word recommendations. Please try again later.');
-            } finally {
-                setIsLoading(false);
+            if (!response.ok) {
+                throw new Error('Failed to fetch word recommendations');
             }
-        };
 
+            const data = await response.json();
+            setRecommendations({
+                word_ids: data.word_ids,
+                improvements: data.improvements,
+                frequencies: data.frequencies
+            });
+        } catch (err) {
+            console.error(err);
+            setError('Failed to load word recommendations. Please try again later.');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
         fetchRecommendations();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [category, fetchWithAuth, language, API_URL]);
 
-    return { recommendations, isLoading, error };
+    const refreshRecommendations = () => {
+        fetchRecommendations();
+    };
+
+    return { recommendations, isLoading, error, refreshRecommendations };
 };


### PR DESCRIPTION
## Summary
- add `refreshRecommendations` method in `useWordRecommendations`
- refresh word recommendations after adding words to user list

## Testing
- `npm run lint` *(fails: `react/no-unescaped-entities` and others)*

------
https://chatgpt.com/codex/tasks/task_e_68445a2cee008328b6ed5c7374d43e7c