### PR TITLE
Fix practice word count

### DIFF
--- a/src/app/vocabulary/page.tsx
+++ b/src/app/vocabulary/page.tsx
@@ -25,7 +25,10 @@ const VocabularyLearnerWithStreak = () => {
   const [wordsDueToday, setWordsDueToday] = useState<any[]>([]);
   const [sourceFilter, setSourceFilter] = useState<string>('all');
 
-  const { overdueWords, error: overdueError } = useOverdueWords(refreshTrigger, {
+  const {
+    words: overdueWords,
+    error: overdueError,
+  } = useOverdueWords(refreshTrigger, {
     source: sourceFilter === 'all' ? undefined : sourceFilter,
   });
   const { topWords, error: topError } = useTopWords(refreshTrigger);


### PR DESCRIPTION
## Summary
- fix the vocabulary page's use of `useOverdueWords`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684460ce3f648328bd9da598a5adf630