### PR TITLE
Add context review mode

### DIFF
--- a/src/app/components/ExampleSentencesList.tsx
+++ b/src/app/components/ExampleSentencesList.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { ExampleEntry } from '@/app/hooks/useExampleSentences';
+
+interface ExampleSentencesListProps {
+  examples: Record<string, ExampleEntry> | null;
+  onContinue: () => void;
+}
+
+const highlightWord = (sentence: string, highlight: string) => {
+  const regex = new RegExp(`\\b${highlight.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'gi');
+  return sentence.replace(regex, match => `<span style="background-color: rgba(255, 165, 0, 0.3);">${match}</span>`);
+};
+
+const ExampleSentencesList: React.FC<ExampleSentencesListProps> = ({ examples, onContinue }) => {
+  if (!examples) return null;
+  return (
+    <div className="max-w-4xl mx-auto p-6 bg-white">
+      <div className="space-y-6">
+        {Object.entries(examples).map(([word, data]) => (
+          <div key={word} className="mb-6">
+            <h2 className="text-xl font-bold text-black mb-3">{word}</h2>
+            <div className="space-y-2">
+              {data.sentences.map((sentence, idx) => (
+                <p
+                  key={idx}
+                  className="text-lg text-gray-800"
+                  dangerouslySetInnerHTML={{
+                    __html: highlightWord(sentence, data.highlights[idx] || word),
+                  }}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="flex justify-end mt-8">
+        <button
+          onClick={onContinue}
+          className="px-6 py-3 rounded-lg font-semibold bg-black text-white hover:bg-gray-800 transition-colors"
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ExampleSentencesList;

--- a/src/app/components/MemoryMatchGame.tsx
+++ b/src/app/components/MemoryMatchGame.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from 'react';
+
+interface Pair {
+  word: string;
+  translation: string;
+}
+
+interface Card {
+  id: string;
+  text: string;
+  type: 'spanish' | 'german';
+  matchId: number;
+}
+
+interface MemoryMatchGameProps {
+  pairs: Pair[];
+  onComplete: () => void;
+}
+
+const MemoryMatchGame: React.FC<MemoryMatchGameProps> = ({ pairs, onComplete }) => {
+  const [selectedCards, setSelectedCards] = useState<Card[]>([]);
+  const [matchedPairs, setMatchedPairs] = useState<Set<number>>(new Set());
+  const [gameCards, setGameCards] = useState<Card[]>([]);
+  const [cardStates, setCardStates] = useState<Record<string, 'correct' | 'incorrect' | undefined>>({});
+
+  useEffect(() => {
+    const spanishCards = pairs.map((p, idx) => ({ id: `s-${idx}`, text: p.word, type: 'spanish' as const, matchId: idx }));
+    const germanCards = pairs.map((p, idx) => ({ id: `g-${idx}`, text: p.translation, type: 'german' as const, matchId: idx }));
+    const shuffledGerman = [...germanCards].sort(() => Math.random() - 0.5);
+    setGameCards([...spanishCards, ...shuffledGerman]);
+    setSelectedCards([]);
+    setMatchedPairs(new Set());
+    setCardStates({});
+  }, [pairs]);
+
+  const handleCardClick = (card: Card) => {
+    if (matchedPairs.has(card.matchId) || selectedCards.find(c => c.id === card.id)) return;
+
+    const newSelected = [...selectedCards, card];
+    setSelectedCards(newSelected);
+
+    if (newSelected.length === 2) {
+      const [first, second] = newSelected;
+      if (first.matchId === second.matchId && first.type !== second.type) {
+        setMatchedPairs(prev => new Set([...prev, first.matchId]));
+        setSelectedCards([]);
+        setCardStates(prev => ({ ...prev, [first.id]: 'correct', [second.id]: 'correct' }));
+        setTimeout(() => {
+          setCardStates(prev => {
+            const n = { ...prev };
+            delete n[first.id];
+            delete n[second.id];
+            return n;
+          });
+        }, 1000);
+      } else {
+        setCardStates(prev => ({ ...prev, [first.id]: 'incorrect', [second.id]: 'incorrect' }));
+        setTimeout(() => {
+          setSelectedCards([]);
+          setCardStates(prev => {
+            const n = { ...prev };
+            delete n[first.id];
+            delete n[second.id];
+            return n;
+          });
+        }, 1000);
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (matchedPairs.size === pairs.length && pairs.length > 0) {
+      onComplete();
+    }
+  }, [matchedPairs, pairs.length, onComplete]);
+
+  const getCardClassName = (card: Card) => {
+    const base = 'p-4 rounded-lg border-2 cursor-pointer transition-all duration-300 text-center font-semibold min-h-16 flex items-center justify-center';
+    if (matchedPairs.has(card.matchId)) return `${base} bg-green-200 border-green-500 text-green-800`;
+    const state = cardStates[card.id];
+    if (state === 'correct') return `${base} bg-green-300 border-green-600 text-green-900 scale-105`;
+    if (state === 'incorrect') return `${base} bg-red-300 border-red-600 text-red-900 shake`;
+    if (selectedCards.find(c => c.id === card.id)) return `${base} bg-blue-200 border-blue-500 text-blue-800`;
+    return `${base} bg-white border-gray-300 text-gray-800 hover:bg-gray-50`;
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 bg-white">
+      <p className="text-center mb-6 text-gray-600">Match Spanish words with German translations</p>
+      <div className="grid grid-cols-2 gap-8 mb-8">
+        <div className="space-y-4">
+          {gameCards.filter(c => c.type === 'spanish').map(card => (
+            <div key={card.id} className={getCardClassName(card)} onClick={() => handleCardClick(card)}>
+              {card.text}
+            </div>
+          ))}
+        </div>
+        <div className="space-y-4">
+          {gameCards.filter(c => c.type === 'german').map(card => (
+            <div key={card.id} className={getCardClassName(card)} onClick={() => handleCardClick(card)}>
+              {card.text}
+            </div>
+          ))}
+        </div>
+      </div>
+      <style jsx>{`
+        .shake {
+          animation: shake 0.5s ease-in-out;
+        }
+        @keyframes shake {
+          0%, 100% { transform: translateX(0); }
+          25% { transform: translateX(-5px); }
+          75% { transform: translateX(5px); }
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default MemoryMatchGame;

--- a/src/app/components/ReviewSection.tsx
+++ b/src/app/components/ReviewSection.tsx
@@ -4,22 +4,34 @@ import { Play } from 'lucide-react';
 interface ReviewSectionProps {
   wordsDueToday: any[];
   onStartReview: () => void;
+  onContextReview?: () => void;
 }
 
-const ReviewSection: React.FC<ReviewSectionProps> = ({ wordsDueToday, onStartReview }) => (
+const ReviewSection: React.FC<ReviewSectionProps> = ({ wordsDueToday, onStartReview, onContextReview }) => (
   <div className="flex items-center justify-between">
     <div>
       <p className="text-2xl font-bold text-gray-800">{wordsDueToday.length}{wordsDueToday.length >= 225 ? '+' : ''}</p>
       <p className="text-md text-gray-600">{wordsDueToday.length === 1 ? 'word' : 'words'} to practice</p>
     </div>
-    <button
-      className="bg-black hover:bg-gray-800 text-white font-bold py-2 px-4 rounded flex items-center"
-      onClick={onStartReview}
-      disabled={wordsDueToday.length === 0}
-    >
-      Start Review
-      <Play className="ml-2 h-4 w-4" />
-    </button>
+    <div className="flex gap-2">
+      <button
+        className="bg-black hover:bg-gray-800 text-white font-bold py-2 px-4 rounded flex items-center"
+        onClick={onStartReview}
+        disabled={wordsDueToday.length === 0}
+      >
+        Start Review
+        <Play className="ml-2 h-4 w-4" />
+      </button>
+      {onContextReview && (
+        <button
+          className="bg-gray-700 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded"
+          onClick={onContextReview}
+          disabled={wordsDueToday.length === 0}
+        >
+          Context
+        </button>
+      )}
+    </div>
   </div>
 );
 

--- a/src/app/hooks/useExampleSentences.ts
+++ b/src/app/hooks/useExampleSentences.ts
@@ -1,0 +1,40 @@
+import { useState, useContext } from 'react';
+import { UserContext } from '@/context/UserContext';
+
+export interface ExampleEntry {
+  sentences: string[];
+  highlights: string[];
+}
+
+export const useExampleSentences = () => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { fetchWithAuth, language } = useContext(UserContext);
+  const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+  const fetchExamples = async (words: string[]) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetchWithAuth(`${API_URL}/api/example-sentences`, {
+        method: 'POST',
+        body: JSON.stringify({
+          words,
+          language: language?.code || 'es',
+        }),
+      });
+      if (!response.ok) {
+        throw new Error('Failed to fetch example sentences');
+      }
+      const data: Record<string, ExampleEntry> = await response.json();
+      return data;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An unknown error occurred');
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { fetchExamples, loading, error };
+};

--- a/src/app/vocabulary/ContextReviewSession.tsx
+++ b/src/app/vocabulary/ContextReviewSession.tsx
@@ -1,0 +1,53 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import ExampleSentencesList from '../components/ExampleSentencesList';
+import MemoryMatchGame from '../components/MemoryMatchGame';
+import { useExampleSentences, ExampleEntry } from '../hooks/useExampleSentences';
+
+interface WordPair {
+  word: string;
+  translation: string;
+}
+
+interface ContextReviewSessionProps {
+  learningSet: WordPair[];
+  onExit: () => void;
+}
+
+const wordsPerPage = 5;
+
+const ContextReviewSession: React.FC<ContextReviewSessionProps> = ({ learningSet, onExit }) => {
+  const [currentPage, setCurrentPage] = useState(0);
+  const [showGame, setShowGame] = useState(false);
+  const [examples, setExamples] = useState<Record<string, ExampleEntry> | null>(null);
+  const { fetchExamples } = useExampleSentences();
+
+  const currentWords = learningSet.slice(currentPage * wordsPerPage, (currentPage + 1) * wordsPerPage);
+
+  useEffect(() => {
+    setShowGame(false);
+    (async () => {
+      const data = await fetchExamples(currentWords.map(w => w.word));
+      setExamples(data);
+    })();
+  }, [currentPage, fetchExamples, currentWords]);
+
+  const handleContinue = () => setShowGame(true);
+
+  const handleGameComplete = () => {
+    const maxPage = Math.ceil(learningSet.length / wordsPerPage) - 1;
+    if (currentPage < maxPage) {
+      setCurrentPage(p => p + 1);
+    } else {
+      onExit();
+    }
+  };
+
+  if (showGame) {
+    return <MemoryMatchGame pairs={currentWords} onComplete={handleGameComplete} />;
+  }
+
+  return <ExampleSentencesList examples={examples} onContinue={handleContinue} />;
+};
+
+export default ContextReviewSession;


### PR DESCRIPTION
## Summary
- support fetching example sentences from the backend
- add components for showing sentences and playing a matching game
- implement context review session for vocabulary practice
- show new review mode button on vocabulary page

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68446df284bc83288ca05d6c8c717a50