### PR TITLE
Fix source filter persistence after flashcards

### DIFF
--- a/src/app/vocabulary/page.tsx
+++ b/src/app/vocabulary/page.tsx
@@ -23,13 +23,13 @@ const VocabularyLearnerWithStreak = () => {
   const [selectedWord, setSelectedWord] = useState<any | null>(null);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
   const [wordsDueToday, setWordsDueToday] = useState<any[]>([]);
-  const [sourceFilter, setSourceFilter] = useState<string>('all');
+  const [sourceFilter, setSourceFilter] = useState<string | null>(null);
 
   const {
     words: overdueWords,
     error: overdueError,
   } = useOverdueWords(refreshTrigger, {
-    source: sourceFilter === 'all' ? undefined : sourceFilter,
+    source: sourceFilter ?? undefined,
   });
   const { topWords, error: topError } = useTopWords(refreshTrigger);
   const { streakData, currentStreak, highestStreak } = useStreakData(refreshTrigger);
@@ -57,7 +57,7 @@ const VocabularyLearnerWithStreak = () => {
     handleRefresh();
   }, [handleRefresh]);
 
-  const handleSourceChange = useCallback((src: string) => {
+  const handleSourceChange = useCallback((src: string | null) => {
     setSourceFilter(src);
   }, []);
 
@@ -118,6 +118,7 @@ const VocabularyLearnerWithStreak = () => {
           <LearningWordsTable
             onMovedToKnown={handleRefresh}
             onSourceChange={handleSourceChange}
+            source={sourceFilter}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- keep selected source via prop and local state
- drop `'all'` pseudo-source in favor of `null`

## Testing
- `npm run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684469ccafe08328b9213d9f991486b2