### PR TITLE
Fix repeated API calls

### DIFF
--- a/src/app/hooks/useExampleSentences.ts
+++ b/src/app/hooks/useExampleSentences.ts
@@ -1,4 +1,4 @@
-import { useState, useContext } from 'react';
+import { useState, useContext, useCallback } from 'react';
 import { UserContext } from '@/context/UserContext';
 
 export interface ExampleEntry {
@@ -12,7 +12,7 @@ export const useExampleSentences = () => {
   const { fetchWithAuth, language } = useContext(UserContext);
   const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
-  const fetchExamples = async (words: string[]) => {
+  const fetchExamples = useCallback(async (words: string[]) => {
     setLoading(true);
     setError(null);
     try {
@@ -34,7 +34,7 @@ export const useExampleSentences = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [fetchWithAuth, language?.code]);
 
   return { fetchExamples, loading, error };
 };

--- a/src/app/hooks/useGetSources.ts
+++ b/src/app/hooks/useGetSources.ts
@@ -1,15 +1,15 @@
 // src/hooks/useGetSources.ts
 import { supabase } from '@/lib/supabaseclient';
+import { useCallback } from 'react';
 
 export const useGetSources = () => {
   /**
    * Fetch all distinct sources for the authenticated user's words,
    * ordered by the earliest created_at timestamp.
    */
-  const getSources = async (): Promise<string[]> => {
+  const getSources = useCallback(async (): Promise<string[]> => {
     try {
-      const { data, error } = await supabase
-        .rpc('get_userword_sources');
+      const { data, error } = await supabase.rpc('get_userword_sources');
 
       if (error) {
         console.error('Supabase RPC error:', error);
@@ -22,7 +22,7 @@ export const useGetSources = () => {
       console.error('Error fetching userword sources:', err);
       throw err;
     }
-  };
+  }, []);
 
   return { getSources };
 };

--- a/src/app/vocabulary/ContextReviewSession.tsx
+++ b/src/app/vocabulary/ContextReviewSession.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import ExampleSentencesList from '../components/ExampleSentencesList';
 import MemoryMatchGame from '../components/MemoryMatchGame';
 import { useExampleSentences, ExampleEntry } from '../hooks/useExampleSentences';
@@ -22,15 +22,18 @@ const ContextReviewSession: React.FC<ContextReviewSessionProps> = ({ learningSet
   const [examples, setExamples] = useState<Record<string, ExampleEntry> | null>(null);
   const { fetchExamples } = useExampleSentences();
 
-  const currentWords = learningSet.slice(currentPage * wordsPerPage, (currentPage + 1) * wordsPerPage);
+  const currentWords = useMemo(
+    () => learningSet.slice(currentPage * wordsPerPage, (currentPage + 1) * wordsPerPage),
+    [currentPage, learningSet]
+  );
 
   useEffect(() => {
     setShowGame(false);
     (async () => {
-      const data = await fetchExamples(currentWords.map(w => w.word));
+      const data = await fetchExamples(currentWords.map((w) => w.word));
       setExamples(data);
     })();
-  }, [currentPage, fetchExamples, currentWords]);
+  }, [currentPage, fetchExamples, learningSet]);
 
   const handleContinue = () => setShowGame(true);
 


### PR DESCRIPTION
## Summary
- memoize word source fetcher so it only runs once
- memoize example sentence hook and page calculations to avoid excessive API requests

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6844b48136848328a2326ab17b6fcbde