### PR TITLE
Fix flashcard restart session filtering

### DIFF
--- a/src/app/session/FlashcardSession.tsx
+++ b/src/app/session/FlashcardSession.tsx
@@ -52,6 +52,10 @@ export const FlashcardSession: React.FC<FlashcardSessionProps> = ({ mode, frontS
 
   // Handler to restart session
   const handleRestart = useCallback(() => {
+    const incorrectCards = initialLearningSet.filter(card =>
+      incorrectCardIds.has(card.id)
+    );
+    setLearningSet(incorrectCards);
     setShowSummary(false);
     setCurrentCardIndex(0);
     setCorrectCardIds(new Set());
@@ -62,7 +66,7 @@ export const FlashcardSession: React.FC<FlashcardSessionProps> = ({ mode, frontS
     setFeedback(null);
     setShowCorrectAnimation(false);
     setWaitForNextButton(false);
-  }, []);
+  }, [incorrectCardIds, initialLearningSet]);
 
   const handleFinishSession = useCallback(() => {
     onExit();


### PR DESCRIPTION
## Summary
- restart flashcard sessions using only incorrect words

## Testing
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68454602db7c8328a23121d869f87f24