### PR TITLE
Fix vocabulary context review highlighting and fetching

### DIFF
--- a/src/app/components/ExampleSentencesList.tsx
+++ b/src/app/components/ExampleSentencesList.tsx
@@ -7,8 +7,12 @@ interface ExampleSentencesListProps {
 }
 
 const highlightWord = (sentence: string, highlight: string) => {
-  const regex = new RegExp(`\\b${highlight.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'gi');
-  return sentence.replace(regex, match => `<span style="background-color: rgba(255, 165, 0, 0.3);">${match}</span>`);
+  const escaped = highlight.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&');
+  const regex = new RegExp(`(?<=^|[^\\p{L}])(${escaped})(?=[^\\p{L}]|$)`, 'giu');
+  return sentence.replace(
+    regex,
+    (_match, word) => `<span style="background-color: rgba(255, 165, 0, 0.3);">${word}</span>`
+  );
 };
 
 const ExampleSentencesList: React.FC<ExampleSentencesListProps> = ({ examples, onContinue }) => {

--- a/src/app/components/MemoryMatchGame.tsx
+++ b/src/app/components/MemoryMatchGame.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 interface Pair {
   word: string;
@@ -22,6 +22,7 @@ const MemoryMatchGame: React.FC<MemoryMatchGameProps> = ({ pairs, onComplete }) 
   const [matchedPairs, setMatchedPairs] = useState<Set<number>>(new Set());
   const [gameCards, setGameCards] = useState<Card[]>([]);
   const [cardStates, setCardStates] = useState<Record<string, 'correct' | 'incorrect' | undefined>>({});
+  const completedRef = useRef(false);
 
   useEffect(() => {
     const spanishCards = pairs.map((p, idx) => ({ id: `s-${idx}`, text: p.word, type: 'spanish' as const, matchId: idx }));
@@ -69,7 +70,8 @@ const MemoryMatchGame: React.FC<MemoryMatchGameProps> = ({ pairs, onComplete }) 
   };
 
   useEffect(() => {
-    if (matchedPairs.size === pairs.length && pairs.length > 0) {
+    if (!completedRef.current && matchedPairs.size === pairs.length && pairs.length > 0) {
+      completedRef.current = true;
       onComplete();
     }
   }, [matchedPairs, pairs.length, onComplete]);

--- a/src/app/vocabulary/ContextReviewSession.tsx
+++ b/src/app/vocabulary/ContextReviewSession.tsx
@@ -31,8 +31,11 @@ const ContextReviewSession: React.FC<ContextReviewSessionProps> = ({ learningSet
     let isMounted = true;
     setShowGame(false);
     setExamples(null);
+    const words = learningSet
+      .slice(currentPage * wordsPerPage, (currentPage + 1) * wordsPerPage)
+      .map((w) => w.word);
     (async () => {
-      const data = await fetchExamples(currentWords.map((w) => w.word));
+      const data = await fetchExamples(words);
       if (isMounted) {
         setExamples(data);
       }
@@ -40,7 +43,7 @@ const ContextReviewSession: React.FC<ContextReviewSessionProps> = ({ learningSet
     return () => {
       isMounted = false;
     };
-  }, [currentPage, fetchExamples, learningSet, currentWords]);
+  }, [currentPage, fetchExamples, learningSet]);
 
   const handleContinue = () => setShowGame(true);
 


### PR DESCRIPTION
## Summary
- correctly highlight accented words in example sentences
- avoid duplicate example sentence requests in context mode

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684593eed7188328971368492623f409